### PR TITLE
カスタムHTMLウィジェットについての修正

### DIFF
--- a/resources/app/setup/widget-area.php
+++ b/resources/app/setup/widget-area.php
@@ -157,7 +157,7 @@ add_action(
 				$wp_page_template = get_post_meta( get_the_ID(), '_wp_page_template', true );
 				if ( ! $wp_page_template || 'default' === $wp_page_template || false !== strpos( $wp_page_template, 'one-column-full.php' ) || false !== strpos( $wp_page_template, 'one-column-fluid.php' ) ) {
 					$params[0]['before_widget'] .= '<div class="c-container">';
-					$params[0]['after_widget']  .= '</div">';
+					$params[0]['after_widget']  .= '</div>';
 				}
 
 				return $params;
@@ -196,7 +196,7 @@ add_action(
 			$wp_page_template = get_post_meta( get_the_ID(), '_wp_page_template', true );
 			if ( ! $wp_page_template || 'default' === $wp_page_template || false !== strpos( $wp_page_template, 'one-column-full.php' ) || false !== strpos( $wp_page_template, 'one-column-fluid.php' ) ) {
 				$params[0]['before_widget'] .= '<div class="c-container">';
-				$params[0]['after_widget']  .= '</div">';
+				$params[0]['after_widget']  .= '</div>';
 			}
 
 			return $params;
@@ -235,7 +235,7 @@ add_action(
 			$wp_page_template = get_theme_mod( 'archive-page-layout' );
 			if ( ! $wp_page_template || 'default' === $wp_page_template || false !== strpos( $wp_page_template, 'one-column-full.php' ) || false !== strpos( $wp_page_template, 'one-column-fluid.php' ) ) {
 				$params[0]['before_widget'] .= '<div class="c-container">';
-				$params[0]['after_widget']  .= '</div">';
+				$params[0]['after_widget']  .= '</div>';
 			}
 
 			return $params;
@@ -274,7 +274,7 @@ add_action(
 				$wp_page_template = get_theme_mod( 'archive-page-layout' );
 				if ( ! $wp_page_template || 'default' === $wp_page_template || false !== strpos( $wp_page_template, 'one-column-full.php' ) || false !== strpos( $wp_page_template, 'one-column-fluid.php' ) ) {
 					$params[0]['before_widget'] .= '<div class="c-container">';
-					$params[0]['after_widget']  .= '</div">';
+					$params[0]['after_widget']  .= '</div>';
 				}
 
 				return $params;


### PR DESCRIPTION
#385 fixed

frontとhomeでカスタムHTMLウィジェットを利用した場合に閉じタグが `</div">` となっていて、
HTMLのエラーが出ていたので修正しました。