### PR TITLE
Googleフォントスタイルと太さを追加してみました

### DIFF
--- a/resources/app/customizer/design/sections/base-design/controls/base-font.php
+++ b/resources/app/customizer/design/sections/base-design/controls/base-font.php
@@ -16,10 +16,12 @@ Framework::control(
 		'priority' => 120,
 		'default'  => 'sans-serif',
 		'choices'  => [
-			'sans-serif'    => __( 'Sans serif', 'snow-monkey' ),
-			'serif'         => __( 'Serif', 'snow-monkey' ),
-			'noto-sans-jp'  => __( 'Noto Sans JP', 'snow-monkey' ),
-			'noto-serif-jp' => __( 'Noto Serif JP', 'snow-monkey' ),
+			'sans-serif'        => __( 'Sans serif', 'snow-monkey' ),
+			'serif'             => __( 'Serif', 'snow-monkey' ),
+			'noto-sans-jp'      => __( 'Noto Sans JP', 'snow-monkey' ),
+			'noto-serif-jp'     => __( 'Noto Serif JP', 'snow-monkey' ),
+			'm-plus-1p'         => __( 'M PLUS 1p', 'snow-monkey' ),
+			'm-plus-rounded-1c' => __( 'M PLUS Rounded 1c', 'snow-monkey' ),
 		],
 	]
 );

--- a/resources/app/customizer/design/sections/base-design/controls/load-font-weight.php
+++ b/resources/app/customizer/design/sections/base-design/controls/load-font-weight.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @package snow-monkey
+ * @author inc2734
+ * @license GPL-2.0+
+ * @version 5.0.0
+ */
+
+use Inc2734\WP_Customizer_Framework\Framework;
+
+Framework::control(
+	'multiple-checkbox',
+	'load-font-weight',
+	[
+		'label'    => __( 'Load font weight', 'snow-monkey' ),
+		'default'  => '400',
+		'priority' => 121,
+		'choices'  => [
+			'100'  => __( 'Thin 100', 'snow-monkey' ),
+			'200'  => __( 'Extra-Light 200', 'snow-monkey' ),
+			'300'  => __( 'Light 300', 'snow-monkey' ),
+			'400'  => __( 'Regular 400', 'snow-monkey' ),
+			'500'  => __( 'Medium 500', 'snow-monkey' ),
+			'600'  => __( 'Semi-Bold 600', 'snow-monkey' ),
+			'700'  => __( 'Bold 700', 'snow-monkey' ),
+			'800'  => __( 'Extra-Bold 800', 'snow-monkey' ),
+			'900'  => __( 'Black 900', 'snow-monkey' ),
+		],
+		'active_callback' => function() {
+			return ('sans-serif') !== get_theme_mod( 'base-font' ) && ('serif') !== get_theme_mod( 'base-font' );
+		},
+	]
+);
+
+if ( ! is_customize_preview() ) {
+	return;
+}
+
+$panel   = Framework::get_panel( 'design' );
+$section = Framework::get_section( 'base-design' );
+$control = Framework::get_control( 'load-font-weight' );
+$control->join( $section )->join( $panel );
+
+add_action('admin_print_footer_scripts', function() {
+  echo <<<EOS
+<script>
+jQuery(function($) {
+
+function fontSelect() {
+
+	const val = $('select#_customize-input-base-font').val();
+	const fontWeights = {
+		'noto-sans-jp' : [100,300,400,500,700,900],
+		'noto-serif-jp' : [200,300,400,500,600,700,900],
+		'm-plus-1p' : [100,300,400,500,700,800,900],
+		'm-plus-rounded-1c' : [100,300,400,500,700,800,900],
+	};
+
+	$('#customize-control-load-font-weight ul li').hide();
+
+	$.each(fontWeights[val], function(index,num) {
+		var n = num / 100 - 1;
+		$('#customize-control-load-font-weight ul li').eq(n).show();
+	});
+
+	if(event.type === 'change') {
+		$('#customize-control-load-font-weight input[type="checkbox"]').prop('checked', false);
+		$('#customize-control-load-font-weight input[value="400"]').prop('checked', true);
+		$('#customize-control-load-font-weight input[value="700"]').prop('checked', true);
+		$('#customize-control-load-font-weight input[type="hidden"]').val('400,700').trigger( 'change' );
+	}
+	
+}
+$(window).on('load',fontSelect);
+$('select#_customize-input-base-font').on('change',fontSelect);
+
+});
+</script>
+EOS;
+});

--- a/resources/src/css/foundation/_body/_body.php
+++ b/resources/src/css/foundation/_body/_body.php
@@ -26,6 +26,14 @@ if ( 'sans-serif' === $base_font ) {
 	$font_family = [ '"Noto Serif JP"', 'serif' ];
 	add_action( 'wp_enqueue_scripts', [ '\Inc2734\WP_Google_Fonts\Helper', 'enqueue_noto_serif_jp' ], 5 );
 	add_action( 'enqueue_block_editor_assets', [ '\Inc2734\WP_Google_Fonts\Helper', 'enqueue_noto_serif_jp' ] );
+} elseif ( 'm-plus-1p' === $base_font ) {
+	$font_family = [ '"M PLUS 1p"', 'sans-serif' ];
+	add_action( 'wp_enqueue_scripts', [ '\Inc2734\WP_Google_Fonts\Helper', 'enqueue_m_plus_1p' ], 5 );
+	add_action( 'enqueue_block_editor_assets', [ '\Inc2734\WP_Google_Fonts\Helper', 'enqueue_m_plus_1p' ] );
+} elseif ( 'm-plus-rounded-1c' === $base_font ) {
+	$font_family = [ '"M PLUS Rounded 1c"', 'sans-serif' ];
+	add_action( 'wp_enqueue_scripts', [ '\Inc2734\WP_Google_Fonts\Helper', 'enqueue_m_plus_rounded_1c' ], 5 );
+	add_action( 'enqueue_block_editor_assets', [ '\Inc2734\WP_Google_Fonts\Helper', 'enqueue_m_plus_rounded_1c' ] );
 }
 
 Style::register(


### PR DESCRIPTION
いまのままだとNotoの太文字が読み込まれていなかったので。
ついでにM PLUSも選択できるようしました。

/vendor/inc2734/wp-google-fonts
/plugins/snow-monkey-editor

もプルリクします