### PR TITLE
Fixed an issue that caused unnecessary queries to be executed in situ…

### DIFF
--- a/app/customizer/design/sections/post-tag/controls/header-image.php
+++ b/app/customizer/design/sections/post-tag/controls/header-image.php
@@ -9,6 +9,10 @@
 use Inc2734\WP_Customizer_Framework\Framework;
 use Framework\Helper;
 
+if ( ! is_customize_preview() ) {
+	return;
+}
+
 $terms = Helper::get_terms(
 	[
 		'taxonomy'   => 'post_tag',
@@ -26,10 +30,6 @@ foreach ( $terms as $_term ) {
 			'priority'    => 110,
 		]
 	);
-}
-
-if ( ! is_customize_preview() ) {
-	return;
 }
 
 $panel = Framework::get_panel( 'design' );


### PR DESCRIPTION
カスタマイザープレビュー時のみでしか使わない `Helper::get_terms()` クエリーを、通常のリクエストでも発行しているため、post_tag が非常に多いサイトで、このクエリがボトルネックになることがあります。
`! is_customize_preview()` の判定する位置を変えただけですが、これによって救われるサイトもあるのでマージのご検討よろしくお願いいたします！